### PR TITLE
Karin noise generation needs to exclude swh at nadir

### DIFF
--- a/swot_simulator/launcher.py
+++ b/swot_simulator/launcher.py
@@ -323,7 +323,8 @@ def simulate(args: Tuple[int, int, np.datetime64],
     # Calculation of instrumental errors
     noise_errors = error_generator.generate(
         cycle_number, pass_number, orbit.curvilinear_distance, track.time,
-        track.x_al, track.x_ac, swh if swh is not None else parameters.swh)
+        track.x_al, track.x_ac,
+        swh[:, :-1] if swh is not None else parameters.swh)
     for error in noise_errors.values():
         # Only the swaths must be masked
         if len(error.shape) == 2:

--- a/swot_simulator/settings.py
+++ b/swot_simulator/settings.py
@@ -314,8 +314,11 @@ class Parameters:
         ssh_plugin=(None, plugins.Interface,
                     ("The plug-in handling the SSH interpolation under the "
                      "satellite swath")),
-        swh_plugin=(None, plugins.Interface,
-                    "SWH plugin to interpolate model SWH on the SWOT grid"),
+        swh_plugin=(
+            None, plugins.Interface,
+            "SWH plugin to interpolate model SWH on the SWOT grid. Use only "
+            "\"expert\" or \"wind_wave\" products that have the swh in its "
+            "output"),
         swath=(True, bool, "True to generate swath products"),
         swh=(2.0, float, "SWH for the region"),
         working_directory=(DEFAULT_WORKING_DIRECTORY, str,


### PR DESCRIPTION
There is a problem in karin noise generation from interpolated swh. The interpolated swh contains swath + nadir, and can not be used in its entirety to compute the karin noise (only swath).

Moreover, if we try to generate the karin noise using swh, the simulator will try to write swh in the output product. If the asked product is basic, the program will fails because basic product has no swh. I modified the documentation so that the user is warned when setting the swh_plugin parameter.